### PR TITLE
Add recently played endpoint with structured logging and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+dev:
+	vercel dev
+
+test:
+	pytest -q
+
+.PHONY: dev test

--- a/README.md
+++ b/README.md
@@ -55,6 +55,27 @@ Please replace your old endpoint `https://spotify-github-profile.vercel.app` to 
 
 
 
+### Recently Played
+
+Render a list of the last tracks you've listened to:
+
+```
+<img src="https://spotify-github-profile.kittinanx.com/api/recently-played?uid=YOUR_SPOTIFY_ID" />
+```
+
+Query parameters:
+
+- `uid` or `user` – Spotify user id. If omitted and only one user token exists in Firestore, that user will be used.
+- `limit` – number of tracks to display (1–10, default 5).
+
+Aliases `/api/recently_played` and `/api/recentlyplayed` redirect to the primary `/api/recently-played` endpoint.
+
+Health check endpoint:
+
+```
+GET /api/ping -> {"ok": true, "time": 1234567890, "version": "dev"}
+```
+
 ## Running for development locally
 
 To develop locally, you need:
@@ -107,6 +128,13 @@ Vercel CLI 20.1.2 dev (beta) — https://vercel.com/feedback
 ```
 
 - Now try to access http://localhost:3000/api/login
+
+### Handy cURL commands
+
+```
+curl -i 'http://localhost:3000/api/recently-played?uid=TEST&limit=3'
+curl -i 'http://localhost:3000/api/ping'
+```
 
 ## How to Contribute
 

--- a/api/callback.py
+++ b/api/callback.py
@@ -11,6 +11,7 @@ import firebase_admin
 import os
 import json
 from util import spotify
+from util.logging_utils import setup_logging
 
 print("Starting Server")
 
@@ -23,6 +24,7 @@ firebase_admin.initialize_app(cred)
 db = firestore.client()
 
 app = Flask(__name__)
+setup_logging(app)
 
 
 @app.route("/", defaults={"path": ""})

--- a/api/login.py
+++ b/api/login.py
@@ -1,8 +1,10 @@
 from flask import Flask, Response, jsonify, render_template, redirect
 
 from util import spotify
+from util.logging_utils import setup_logging
 
 app = Flask(__name__)
+setup_logging(app)
 
 
 @app.route("/", defaults={"path": ""})

--- a/api/ping.py
+++ b/api/ping.py
@@ -1,0 +1,23 @@
+import time
+import os
+
+from flask import Flask, jsonify
+
+from util.logging_utils import setup_logging
+
+
+app = Flask(__name__)
+setup_logging(app)
+
+
+@app.route("/api/ping", methods=["GET"])
+def ping():
+    return jsonify(
+        {
+            "ok": True,
+            "time": int(time.time()),
+            "version": os.getenv("VERSION", "dev"),
+        }
+    )
+
+

--- a/api/recently_played.py
+++ b/api/recently_played.py
@@ -1,89 +1,144 @@
-# api/recently_played.py
-import os, json, base64, time, requests
-from flask import Flask, request, Response
-import firebase_admin
-from firebase_admin import credentials, firestore
+import html
+import time
+from typing import Any, Dict
+
+from flask import Flask, Response, request, redirect
+
+from util.firestore import get_firestore_db
+from util import spotify
+from util.logging_utils import setup_logging
+
 
 app = Flask(__name__)
-app.url_map.strict_slashes = False  
+setup_logging(app)
 
-def _init_firestore():
-    b64 = os.environ.get("FIREBASE")
-    cred = json.loads(base64.b64decode(b64))
-    if not firebase_admin._apps:
-        firebase_admin.initialize_app(credentials.Certificate(cred))
-    return firestore.client()
+CACHE_CONTROL = "public, max-age=60, stale-while-revalidate=30"
 
-def _get_tokens(db, uid):
+
+def parse_limit(value: Any) -> int:
+    try:
+        num = int(value)
+    except (TypeError, ValueError):
+        return 5
+    return max(1, min(num, 10))
+
+
+def _escape(text: str) -> str:
+    return html.escape(text or "")
+
+
+def render_svg(items) -> str:
+    width, line_h, pad = 700, 22, 16
+    lines = [
+        f'<text x="0" y="{pad}" font-size="18" font-weight="bold">Recently played</text>'
+    ]
+    y = pad + 26
+    for i, it in enumerate(items, 1):
+        track = it.get("track", {})
+        name = track.get("name", "")
+        artists = ", ".join(a.get("name", "") for a in track.get("artists", []))
+        lines.append(
+            f'<text x="0" y="{y}" font-size="14">{i}. {_escape(name)} — {_escape(artists)}</text>'
+        )
+        y += line_h
+    height = max(y + pad, 80)
+    body = (
+        "\n".join(lines)
+        if items
+        else '<text x="0" y="30" font-size="14">No recent tracks</text>'
+    )
+    return (
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}">'
+        "<style>text { font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif;"
+        " fill: #e6edf3; }svg { background: #0d1117; }</style>"
+        f'<g transform="translate(16,8)">{body}</g></svg>'
+    )
+
+
+def render_error(msg: str) -> str:
+    return (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="400" height="60">'
+        "<style>text { font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif;"
+        " fill: #e6edf3; }svg { background: #0d1117; }</style>"
+        f'<text x="10" y="35" font-size="14">{_escape(msg)}</text></svg>'
+    )
+
+
+def _svg_response(svg: str) -> Response:
+    resp = Response(svg, mimetype="image/svg+xml")
+    resp.headers["Cache-Control"] = CACHE_CONTROL
+    return resp
+
+
+def _get_user_id(db) -> str:
+    uid = request.args.get("uid") or request.args.get("user")
+    if uid:
+        # allow only alphanumeric user ids
+        return "".join(ch for ch in uid if ch.isalnum())
+    users = list(db.collection("users").stream())
+    if len(users) == 1:
+        return users[0].id
+    return ""
+
+
+def _get_tokens(db, uid: str) -> Dict[str, Any]:
     doc = db.collection("users").document(uid).get()
     if not doc.exists:
-        raise RuntimeError("Firestore document not found")
+        raise RuntimeError("user not found")
     return doc.to_dict()
 
-def _refresh_access_token(refresh_token):
-    r = requests.post(
-        "https://accounts.spotify.com/api/token",
-        data={"grant_type": "refresh_token", "refresh_token": refresh_token},
-        auth=(os.environ["SPOTIFY_CLIENT_ID"], os.environ["SPOTIFY_SECRET_ID"]),
-        timeout=10,
-    )
-    r.raise_for_status()
-    return r.json()
 
-def _ensure_access_token(db, uid, info):
+def _ensure_access_token(db, uid: str, info: Dict[str, Any]) -> str:
     now = int(time.time())
     if info.get("token_expired_timestamp", 0) <= now:
-        new_info = _refresh_access_token(info["refresh_token"])
-        info.update({
-            "access_token": new_info["access_token"],
-            "token_expired_timestamp": now + int(new_info.get("expires_in", 3600)) - 30
-        })
+        refreshed = spotify.refresh_token(info["refresh_token"])
+        info.update(
+            {
+                "access_token": refreshed["access_token"],
+                "token_expired_timestamp": now + int(refreshed.get("expires_in", 3600)) - 30,
+            }
+        )
         db.collection("users").document(uid).set(info, merge=True)
     return info["access_token"]
 
-def _escape(s): return (s or "").replace("&","&amp;").replace("<","&lt;").replace(">","&gt;")
-
-def _render_svg(items, title="Recently played"):
-    width, line_h, pad = 700, 22, 16
-    lines = [f'<text x="0" y="{pad}" font-size="18" font-weight="bold">{_escape(title)}</text>']
-    y = pad + 26
-    for i, it in enumerate(items[:10], 1):
-        track = (it or {}).get("track", {})
-        name = track.get("name","")
-        artists = ", ".join(a.get("name","") for a in track.get("artists",[]))
-        lines.append(f'<text x="0" y="{y}" font-size="14">{i}. {_escape(name)} — {_escape(artists)}</text>')
-        y += line_h
-    height = max(y + pad, 80)
-    body = "\n".join(lines) if items else '<text x="0" y="30" font-size="14">No recent tracks</text>'
-    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}">
-<style>text {{ font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif; fill: #e6edf3; }}
-svg {{ background: #0d1117; }}</style>
-        <g transform="translate(16,8)">{body}</g></svg>'''
-
 
 @app.route("/api/recently_played", methods=["GET"])
-@app.route("/api/recently_played/", methods=["GET"])
-@app.route("/api/recently-played", methods=["GET"])
-@app.route("/api/recently-played/", methods=["GET"])
-@app.route("/api/recently-played.svg", methods=["GET"])
-def recently_played_svg():
-    uid = request.args.get("uid")
-    limit = int(request.args.get("count", 10))
-    if not uid:
-        return Response("uid is required", status=400)
-    db = _init_firestore()
-    info = _get_tokens(db, uid)
-    token = _ensure_access_token(db, uid, info)
-    r = requests.get(
-        "https://api.spotify.com/v1/me/player/recently-played",
-        headers={"Authorization": f"Bearer {token}"},
-        params={"limit": limit},
-        timeout=10,
-    )
-    r.raise_for_status()
-    svg = _render_svg(r.json().get("items", []))
-    return Response(svg, mimetype="image/svg+xml")
+@app.route("/api/recentlyplayed", methods=["GET"])
+def recently_played_redirect():
+    return redirect("/api/recently-played", code=301)
 
-@app.route("/api/recently_played/ping", methods=["GET"])
-def ping():
-    return Response("ok", mimetype="text/plain")
+
+@app.route("/api/recently-played", methods=["GET"])
+def recently_played_view():
+    limit = parse_limit(request.args.get("limit"))
+    db = get_firestore_db()
+    uid = _get_user_id(db)
+    if not uid:
+        svg = render_error("Please provide ?uid=<spotify id>")
+        return _svg_response(svg)
+    try:
+        info = _get_tokens(db, uid)
+        token = _ensure_access_token(db, uid, info)
+        try:
+            data = spotify.get_recently_play(token, limit=10)
+        except spotify.InvalidTokenError:
+            refreshed = spotify.refresh_token(info["refresh_token"])
+            info.update(
+                {
+                    "access_token": refreshed["access_token"],
+                    "token_expired_timestamp": int(time.time())
+                    + int(refreshed.get("expires_in", 3600))
+                    - 30,
+                }
+            )
+            db.collection("users").document(uid).set(info, merge=True)
+            data = spotify.get_recently_play(info["access_token"], limit=10)
+        items = data.get("items", [])[:limit]
+        svg = render_svg(items)
+        return _svg_response(svg)
+    except spotify.RateLimitError:
+        return _svg_response(render_error("Spotify rate limit"))
+    except Exception as e:  # noqa: BLE001
+        return _svg_response(render_error(str(e)))
+
+

--- a/api/view.py
+++ b/api/view.py
@@ -3,6 +3,7 @@ from base64 import b64decode, b64encode
 from dotenv import load_dotenv, find_dotenv
 
 from util.firestore import get_firestore_db
+from util.logging_utils import setup_logging
 
 load_dotenv(find_dotenv())
 
@@ -28,6 +29,7 @@ db = get_firestore_db()
 CACHE_TOKEN_INFO = {}
 
 app = Flask(__name__)
+setup_logging(app)
 
 
 @functools.lru_cache(maxsize=128)

--- a/tests/golden_recently_played.svg
+++ b/tests/golden_recently_played.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="102"><style>text { font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif; fill: #e6edf3; }svg { background: #0d1117; }</style><g transform="translate(16,8)"><text x="0" y="16" font-size="18" font-weight="bold">Recently played</text>
+<text x="0" y="42" font-size="14">1. T1 — A1</text>
+<text x="0" y="64" font-size="14">2. T2 — A2</text></g></svg>

--- a/tests/test_recently_played.py
+++ b/tests/test_recently_played.py
@@ -1,0 +1,168 @@
+import os
+import sys
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from api.recently_played import app, parse_limit
+from util import spotify
+
+
+class FakeDoc:
+    def __init__(self, data, uid):
+        self._data = data
+        self.id = uid
+        self.exists = data is not None
+
+    def to_dict(self):
+        return self._data
+
+
+class FakeDB:
+    def __init__(self, docs):
+        self.docs = docs
+
+    def collection(self, name):
+        assert name == "users"
+        return self
+
+    def document(self, uid):
+        db = self
+
+        class Ref:
+            def get(self):
+                data = db.docs.get(uid)
+                return FakeDoc(data, uid)
+
+            def set(self, info, merge=True):
+                db.docs.setdefault(uid, {}).update(info)
+
+        return Ref()
+
+    def stream(self):
+        for uid, data in self.docs.items():
+            yield FakeDoc(data, uid)
+
+
+@pytest.fixture
+def client():
+    app.config.update({"TESTING": True})
+    return app.test_client()
+
+
+def test_parse_limit_clamp():
+    assert parse_limit(None) == 5
+    assert parse_limit("0") == 1
+    assert parse_limit("11") == 10
+    assert parse_limit("3") == 3
+
+
+def test_alias_redirects(client):
+    r = client.get("/api/recently_played")
+    assert r.status_code == 301
+    assert r.headers["Location"].endswith("/api/recently-played")
+    r = client.get("/api/recentlyplayed")
+    assert r.status_code == 301
+    assert r.headers["Location"].endswith("/api/recently-played")
+
+
+def test_empty_list_returns_message(client, monkeypatch):
+    db = FakeDB({"u1": {"access_token": "t", "refresh_token": "r", "token_expired_timestamp": int(time.time()) + 60}})
+    monkeypatch.setattr("api.recently_played.get_firestore_db", lambda: db)
+    monkeypatch.setattr("util.spotify.get_recently_play", lambda token, limit=10: {"items": []})
+    resp = client.get("/api/recently-played?uid=u1")
+    assert resp.status_code == 200
+    assert b"No recent tracks" in resp.data
+
+
+def test_error_rate_limit_returns_svg(client, monkeypatch):
+    db = FakeDB({"u1": {"access_token": "t", "refresh_token": "r", "token_expired_timestamp": int(time.time()) + 60}})
+    monkeypatch.setattr("api.recently_played.get_firestore_db", lambda: db)
+    monkeypatch.setattr(
+        "util.spotify.get_recently_play",
+        lambda *a, **k: (_ for _ in ()).throw(spotify.RateLimitError("x")),
+    )
+    resp = client.get("/api/recently-played?uid=u1")
+    assert resp.status_code == 200
+    assert b"rate limit" in resp.data.lower()
+
+
+def test_success_path(client, monkeypatch):
+    items = [
+        {"track": {"name": f"S{i}", "artists": [{"name": f"A{i}"}]}} for i in range(5)
+    ]
+    db = FakeDB(
+        {
+            "u1": {
+                "access_token": "t",
+                "refresh_token": "r",
+                "token_expired_timestamp": int(time.time()) + 60,
+            }
+        }
+    )
+    monkeypatch.setattr("api.recently_played.get_firestore_db", lambda: db)
+    monkeypatch.setattr("util.spotify.get_recently_play", lambda token, limit=10: {"items": items})
+    resp = client.get("/api/recently-played?uid=u1&limit=5")
+    text = resp.data.decode()
+    assert text.count("</text>") - 1 == 5  # minus header line
+    assert resp.headers["Cache-Control"].startswith("public")
+
+
+def test_token_refresh_flow(client, monkeypatch):
+    items = {"items": [{"track": {"name": "S", "artists": [{"name": "A"}]}}]}
+    db = FakeDB(
+        {
+            "u1": {
+                "access_token": "old",
+                "refresh_token": "r",
+                "token_expired_timestamp": int(time.time()) + 60,
+            }
+        }
+    )
+    monkeypatch.setattr("api.recently_played.get_firestore_db", lambda: db)
+
+    calls = {"refresh": 0, "play": 0}
+
+    def fake_get(token, limit=10):
+        calls["play"] += 1
+        if calls["play"] == 1:
+            raise spotify.InvalidTokenError("bad")
+        return items
+
+    def fake_refresh(refresh):
+        calls["refresh"] += 1
+        return {"access_token": "new", "expires_in": 3600}
+
+    monkeypatch.setattr("util.spotify.get_recently_play", fake_get)
+    monkeypatch.setattr("util.spotify.refresh_token", fake_refresh)
+
+    resp = client.get("/api/recently-played?uid=u1")
+    assert resp.status_code == 200
+    assert calls["play"] == 2
+    assert calls["refresh"] == 1
+    assert db.docs["u1"]["access_token"] == "new"
+
+
+def test_snapshot_svg(client, monkeypatch):
+    items = [
+        {"track": {"name": "T1", "artists": [{"name": "A1"}]}},
+        {"track": {"name": "T2", "artists": [{"name": "A2"}]}},
+    ]
+    db = FakeDB(
+        {
+            "u1": {
+                "access_token": "t",
+                "refresh_token": "r",
+                "token_expired_timestamp": int(time.time()) + 60,
+            }
+        }
+    )
+    monkeypatch.setattr("api.recently_played.get_firestore_db", lambda: db)
+    monkeypatch.setattr("util.spotify.get_recently_play", lambda *a, **k: {"items": items})
+    resp = client.get("/api/recently-played?uid=u1&limit=2")
+    with open("tests/golden_recently_played.svg", "r", encoding="utf-8") as f:
+        expected = f.read().strip()
+    assert resp.data.decode().strip() == expected
+

--- a/util/logging_utils.py
+++ b/util/logging_utils.py
@@ -1,0 +1,41 @@
+import json
+import logging
+import time
+import uuid
+
+from flask import request, g
+
+
+def setup_logging(app):
+    """Configure basic structured logging for a Flask app."""
+    logger = logging.getLogger("spotify-profile")
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+    @app.before_request
+    def _start_timer():
+        g._start_time = time.time()
+        g.request_id = str(uuid.uuid4())
+
+    @app.after_request
+    def _log_request(response):
+        duration = int((time.time() - g.get("_start_time", time.time())) * 1000)
+        payload = {
+            "request_id": g.get("request_id"),
+            "path": request.path,
+            "query": request.query_string.decode("utf-8"),
+            "user_id": request.args.get("uid") or request.args.get("user"),
+            "status": response.status_code,
+            "duration_ms": duration,
+        }
+        logger.info(json.dumps(payload))
+        response.headers["X-Request-ID"] = g.get("request_id")
+        return response
+
+    @app.teardown_request
+    def _log_error(exc):
+        if exc is not None:
+            logger.exception("request failed", exc_info=exc)
+

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "functions": {
+    "api/*.py": { "runtime": "python3.11" }
+  },
+  "redirects": [
+    { "source": "/api/recently_played", "destination": "/api/recently-played", "permanent": true },
+    { "source": "/api/recentlyplayed", "destination": "/api/recently-played", "permanent": true }
+  ]
+}
+


### PR DESCRIPTION
## Summary
- add `/api/recently-played` endpoint with alias redirects, token refresh, and SVG rendering
- provide `/api/ping` health check and structured request logging
- configure Vercel, Makefile, and comprehensive tests for recently played

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b6a603d8b0832d8b7b880da339b2dc