### PR TITLE
Add Jinja-based recently played SVG with caching

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,17 @@
+name: tests
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r api/requirements.txt
+      - run: pip install pytest
+      - run: pytest

--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ curl -i 'http://localhost:3000/api/recently-played?uid=TEST&limit=3'
 curl -i 'http://localhost:3000/api/ping'
 ```
 
+## Troubleshooting
+
+- **404 errors** – confirm the route file exists and that `vercel.json` contains the correct rewrites for the endpoint.
+- **No logs** – ensure the Flask application prints or logs to stdout so Vercel captures output.
+- **Paused project** – verify the Vercel project is active and not paused, otherwise requests will fail silently.
+
 ## How to Contribute
 
 - Develop locally and submit a pull request!

--- a/api/templates/recently-played.svg.j2
+++ b/api/templates/recently-played.svg.j2
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="{{ width }}" height="{{ height }}">
+  <style>
+    text { font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif; fill: #e6edf3; }
+    svg { background: #0d1117; }
+  </style>
+  <g transform="translate({{ pad }}, {{ pad }})">
+    <text x="0" y="0" font-size="18" font-weight="bold">Recently played</text>
+    {% if items -%}
+    {% for item in items -%}
+      {% set track = item.track %}
+      {% set artists = track.artists | map(attribute='name') | join(', ') %}
+      {% set y = 24 + row_h * loop.index0 %}
+      {% if track.album and track.album.images -%}
+        <image x="0" y="{{ y - img + 8 }}" width="{{ img }}" height="{{ img }}" href="{{ track.album.images[0].url }}" />
+        <text x="{{ img + 8 }}" y="{{ y }}" font-size="14">{{ loop.index }}. {{ track.name|e }} - {{ artists|e }}</text>
+      {% else -%}
+        <text x="0" y="{{ y }}" font-size="14">{{ loop.index }}. {{ track.name|e }} - {{ artists|e }}</text>
+      {% endif -%}
+    {% endfor -%}
+    {% else -%}
+      <text x="0" y="30" font-size="14">No recent tracks</text>
+    {% endif -%}
+  </g>
+</svg>

--- a/tests/golden_recently_played.svg
+++ b/tests/golden_recently_played.svg
@@ -1,3 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="700" height="102"><style>text { font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif; fill: #e6edf3; }svg { background: #0d1117; }</style><g transform="translate(16,8)"><text x="0" y="16" font-size="18" font-weight="bold">Recently played</text>
-<text x="0" y="42" font-size="14">1. T1 — A1</text>
-<text x="0" y="64" font-size="14">2. T2 — A2</text></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="104">
+  <style>
+    text { font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif; fill: #e6edf3; }
+    svg { background: #0d1117; }
+  </style>
+  <g transform="translate(16, 16)">
+    <text x="0" y="0" font-size="18" font-weight="bold">Recently played</text>
+    
+      
+      
+      <image x="0" y="0" width="32" height="32" href="https://img/1" />
+        <text x="40" y="24" font-size="14">1. T1 - A1</text>
+      
+      
+      
+      <image x="0" y="40" width="32" height="32" href="https://img/2" />
+        <text x="40" y="64" font-size="14">2. T2 - A2</text>
+      </g>
+</svg>


### PR DESCRIPTION
## Summary
- Render `/api/recently-played` using a Jinja2 SVG template and log requests
- Add ETag handling and short-timeout Spotify requests with a simple retry
- Document troubleshooting steps and add CI tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b6aa17b4fc832d96fdb14875a111c2