### PR TITLE
feat: add spotify theme card

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ Aliases `/api/recently_played` and `/api/recentlyplayed` redirect to the primary
 ### 🎧 Recently Played (Spotify Theme)
 ![Spotify Recently Played](https://<your-app>.vercel.app/api/recently-played?limit=5&theme=spotify)
 
-Optional width control:
+Optional width in Markdown:
 
-<img src="https://<your-app>.vercel.app/api/recently-played?limit=5&theme=spotify&width=600" />
+<img src="https://<your-app>.vercel.app/api/recently-played?limit=5&theme=spotify" width="720" />
 
 Health check endpoint:
 

--- a/api/templates/recently_played_spotify.svg.j2
+++ b/api/templates/recently_played_spotify.svg.j2
@@ -1,39 +1,60 @@
-{% set row_h = 64 %}
-{% set header_h = 64 %}
-{% set pad = 24 %}
-{% set H = header_h + (items|length) * row_h %}
 {% set W = W or 920 %}
-<svg xmlns="http://www.w3.org/2000/svg" width="{{ W }}" height="{{ H }}" viewBox="0 0 {{ W }} {{ H }}">
-  <style>
-    .f{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Arial,"Helvetica Neue",sans-serif;}
-    .title{font-size:24px;font-weight:700;fill:#ffffff;}
-    .track{font-size:16px;font-weight:700;fill:#ffffff;}
-    .artist{font-size:14px;fill:#A7A7A7;}
-    .time{font-size:14px;fill:#A7A7A7;text-anchor:end;}
-    .sep{stroke:#24292E;stroke-width:1;}
-  </style>
-  <rect width="100%" height="100%" rx="16" ry="16" fill="#161819" />
-  <g transform="translate({{pad}},32)">
-    <svg x="0" y="-12" width="24" height="24" viewBox="0 0 24 24">
-      <path fill="#1DB954" d="M12 0C5.371 0 0 5.371 0 12s5.371 12 12 12 12-5.371 12-12S18.629 0 12 0zm5.473 17.303a.748.748 0 01-1.028.245c-2.818-1.744-6.366-2.137-10.548-1.17a.75.75 0 11-.329-1.464c4.585-1.029 8.493-.571 11.494 1.361.35.217.46.677.245 1.028zm1.316-2.936a.937.937 0 01-1.284.306c-3.231-1.98-8.146-2.556-11.939-1.405a.938.938 0 01-.548-1.795c4.236-1.294 9.633-.667 13.341 1.64a.937.937 0 01.43 1.254zm.127-3.124c-3.705-2.174-9.36-2.372-12.714-1.304a1.125 1.125 0 11-.658-2.152c4.027-1.233 10.251-1.01 14.513 1.566a1.125 1.125 0 01-1.141 1.89z"/>
-    </svg>
-    <text x="32" y="0" class="f title">Spotify</text>
-    <text x="32" y="28" class="f title">Recently Played</text>
-  </g>
-  <line x1="0" y1="{{header_h}}" x2="{{W}}" y2="{{header_h}}" class="sep"/>
-  {% for it in items %}
-    {% set y = header_h + loop.index0 * row_h %}
-    <g transform="translate({{pad}}, {{ y + 10 }})">
-      <defs>
-        <clipPath id="cover{{ loop.index }}">
-          <rect width="44" height="44" rx="6" ry="6"/>
-        </clipPath>
-      </defs>
-      <image href="{{ it.cover }}" width="44" height="44" clip-path="url(#cover{{ loop.index }})" />
-      <text x="56" y="20" class="f track">{{ it.title }}</text>
-      <text x="56" y="40" class="f artist">{{ it.artist }}</text>
-      <text x="{{ W - pad*2 }}" y="32" class="f time">{{ it.when }}</text>
+{% set ROW_H = 88 %}
+{% set PAD_X = 28 %}
+{% set PAD_Y = 24 %}
+{% set R = 18 %}
+{% set TITLE_SPOTIFY = 26 %}
+{% set TITLE_RP = 26 %}
+{% set TRACK_SIZE = 22 %}
+{% set ARTIST_SIZE = 18 %}
+{% set TIME_SIZE = 16 %}
+{% set ROWS = items|length %}
+{% set H = PAD_Y*2 + 48 + ROWS*ROW_H %}
+
+<svg xmlns="http://www.w3.org/2000/svg" width="{{ W }}" height="{{ H }}" viewBox="0 0 {{ W }} {{ H }}" role="img" aria-label="Spotify Recently Played">
+  <defs>
+    <style>
+      .card  { fill:#171A1C; }
+      .tSpot { fill:#1DB954; font: {{ TITLE_SPOTIFY }}px/1.2 -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Arial,"Helvetica Neue",sans-serif; font-weight:800; }
+      .tHead { fill:#EDEFF1;     font: {{ TITLE_RP }}px/1.2       -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Arial,"Helvetica Neue",sans-serif; font-weight:800; }
+      .track { fill:#F4F6F8;     font: {{ TRACK_SIZE }}px/1.25    -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Arial,"Helvetica Neue",sans-serif; font-weight:800; }
+      .artist{ fill:#A7AFB8;     font: {{ ARTIST_SIZE }}px/1.35   -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Arial,"Helvetica Neue",sans-serif; font-weight:600; }
+      .time  { fill:#9AA3AE;     font: {{ TIME_SIZE }}px/1        -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Arial,"Helvetica Neue",sans-serif; text-anchor:end; }
+      .sep   { stroke:#2B2F33; stroke-width:1; opacity:.9; }
+      .logo  { fill:#1DB954; }
+      image  { clip-path:url(#cover); }
+    </style>
+    <clipPath id="cover">
+      <rect rx="8" ry="8" width="56" height="56"/>
+    </clipPath>
+  </defs>
+
+  <rect x="0" y="0" width="{{ W }}" height="{{ H }}" rx="{{ R }}" ry="{{ R }}" class="card"/>
+
+  <g transform="translate({{ PAD_X }}, {{ PAD_Y }})">
+    <g transform="translate(0,0) scale(1.2)">
+      <path class="logo" d="M30 15c8.28 0 15 6.72 15 15s-6.72 15-15 15S15 38.28 15 30 21.72 15 30 15zm6.77 22.25a1.88 1.88 0 0 0-2.58-.63c-3.04 1.86-6.87 2.28-11.38 1.24a1.88 1.88 0 1 0-.82 3.65c5.30 1.19 9.77.67 13.30-1.53.83-.51 1.08-1.6.48-2.73zm1.52-6.18a2.25 2.25 0 0 0-3.10-.76c-3.54 2.16-8.95 2.80-15.03 1.53a2.25 2.25 0 0 0-.93 4.40c7.00 1.48 13.31.74 17.72-1.94a2.25 2.25 0 0 0 .34-3.23zm.38-6.26a2.63 2.63 0 0 0-3.62-.88c-3.97 2.43-10.61 3.23-17.77 1.76a2.63 2.63 0 1 0-1.09 5.14c8.09 1.71 15.78.85 20.90-2.23a2.63 2.63 0 0 0 .58-3.79z"/>
     </g>
-    <line x1="0" y1="{{ y + row_h }}" x2="{{ W }}" y2="{{ y + row_h }}" class="sep"/>
+    <text x="64" y="30" class="tSpot">Spotify</text>
+    <text x="184" y="30" class="tHead">Recently Played</text>
+  </g>
+
+  <line x1="0" x2="{{ W }}" y1="{{ PAD_Y + 50 }}" y2="{{ PAD_Y + 50 }}" class="sep"/>
+
+  {% for it in items %}
+    {% set y = PAD_Y + 50 + (loop.index0 * ROW_H) %}
+    <g transform="translate({{ PAD_X }}, {{ y }})">
+      {% if it.cover %}
+        <image href="{{ it.cover }}" x="0" y="16" width="56" height="56"/>
+      {% else %}
+        <rect x="0" y="16" width="56" height="56" rx="8" ry="8" fill="#2B2F33"/>
+      {% endif %}
+      <text x="76" y="44" class="track">{{ it.title }}</text>
+      <text x="76" y="68" class="artist">{{ it.artist }}</text>
+      <text x="{{ W - PAD_X }}" y="52" class="time">{{ it.when }}</text>
+    </g>
+    {% if not loop.last %}
+      <line x1="{{ PAD_X }}" x2="{{ W - PAD_X }}" y1="{{ y + ROW_H }}" y2="{{ y + ROW_H }}" class="sep"/>
+    {% endif %}
   {% endfor %}
 </svg>

--- a/tests/golden_spotify_theme.svg
+++ b/tests/golden_spotify_theme.svg
@@ -1,62 +1,69 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="920" height="256" viewBox="0 0 920 256">
-  <style>
-    .f{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Arial,"Helvetica Neue",sans-serif;}
-    .title{font-size:24px;font-weight:700;fill:#ffffff;}
-    .track{font-size:16px;font-weight:700;fill:#ffffff;}
-    .artist{font-size:14px;fill:#A7A7A7;}
-    .time{font-size:14px;fill:#A7A7A7;text-anchor:end;}
-    .sep{stroke:#24292E;stroke-width:1;}
-  </style>
-  <rect width="100%" height="100%" rx="16" ry="16" fill="#161819" />
-  <g transform="translate(24,32)">
-    <svg x="0" y="-12" width="24" height="24" viewBox="0 0 24 24">
-      <path fill="#1DB954" d="M12 0C5.371 0 0 5.371 0 12s5.371 12 12 12 12-5.371 12-12S18.629 0 12 0zm5.473 17.303a.748.748 0 01-1.028.245c-2.818-1.744-6.366-2.137-10.548-1.17a.75.75 0 11-.329-1.464c4.585-1.029 8.493-.571 11.494 1.361.35.217.46.677.245 1.028zm1.316-2.936a.937.937 0 01-1.284.306c-3.231-1.98-8.146-2.556-11.939-1.405a.938.938 0 01-.548-1.795c4.236-1.294 9.633-.667 13.341 1.64a.937.937 0 01.43 1.254zm.127-3.124c-3.705-2.174-9.36-2.372-12.714-1.304a1.125 1.125 0 11-.658-2.152c4.027-1.233 10.251-1.01 14.513 1.566a1.125 1.125 0 01-1.141 1.89z"/>
-    </svg>
-    <text x="32" y="0" class="f title">Spotify</text>
-    <text x="32" y="28" class="f title">Recently Played</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="360" viewBox="0 0 920 360" role="img" aria-label="Spotify Recently Played">
+  <defs>
+    <style>
+      .card  { fill:#171A1C; }
+      .tSpot { fill:#1DB954; font: 26px/1.2 -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Arial,"Helvetica Neue",sans-serif; font-weight:800; }
+      .tHead { fill:#EDEFF1;     font: 26px/1.2       -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Arial,"Helvetica Neue",sans-serif; font-weight:800; }
+      .track { fill:#F4F6F8;     font: 22px/1.25    -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Arial,"Helvetica Neue",sans-serif; font-weight:800; }
+      .artist{ fill:#A7AFB8;     font: 18px/1.35   -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Arial,"Helvetica Neue",sans-serif; font-weight:600; }
+      .time  { fill:#9AA3AE;     font: 16px/1        -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Arial,"Helvetica Neue",sans-serif; text-anchor:end; }
+      .sep   { stroke:#2B2F33; stroke-width:1; opacity:.9; }
+      .logo  { fill:#1DB954; }
+      image  { clip-path:url(#cover); }
+    </style>
+    <clipPath id="cover">
+      <rect rx="8" ry="8" width="56" height="56"/>
+    </clipPath>
+  </defs>
+
+  <rect x="0" y="0" width="920" height="360" rx="18" ry="18" class="card"/>
+
+  <g transform="translate(28, 24)">
+    <g transform="translate(0,0) scale(1.2)">
+      <path class="logo" d="M30 15c8.28 0 15 6.72 15 15s-6.72 15-15 15S15 38.28 15 30 21.72 15 30 15zm6.77 22.25a1.88 1.88 0 0 0-2.58-.63c-3.04 1.86-6.87 2.28-11.38 1.24a1.88 1.88 0 1 0-.82 3.65c5.30 1.19 9.77.67 13.30-1.53.83-.51 1.08-1.6.48-2.73zm1.52-6.18a2.25 2.25 0 0 0-3.10-.76c-3.54 2.16-8.95 2.80-15.03 1.53a2.25 2.25 0 0 0-.93 4.40c7.00 1.48 13.31.74 17.72-1.94a2.25 2.25 0 0 0 .34-3.23zm.38-6.26a2.63 2.63 0 0 0-3.62-.88c-3.97 2.43-10.61 3.23-17.77 1.76a2.63 2.63 0 1 0-1.09 5.14c8.09 1.71 15.78.85 20.90-2.23a2.63 2.63 0 0 0 .58-3.79z"/>
+    </g>
+    <text x="64" y="30" class="tSpot">Spotify</text>
+    <text x="184" y="30" class="tHead">Recently Played</text>
   </g>
-  <line x1="0" y1="64" x2="920" y2="64" class="sep"/>
+
+  <line x1="0" x2="920" y1="74" y2="74" class="sep"/>
+
   
     
-    <g transform="translate(24, 74)">
-      <defs>
-        <clipPath id="cover1">
-          <rect width="44" height="44" rx="6" ry="6"/>
-        </clipPath>
-      </defs>
-      <image href="https://img/1" width="44" height="44" clip-path="url(#cover1)" />
-      <text x="56" y="20" class="f track">T1</text>
-      <text x="56" y="40" class="f artist">A1</text>
-      <text x="872" y="32" class="f time">2024-01-01</text>
+    <g transform="translate(28, 74)">
+      
+        <image href="https://img/1" x="0" y="16" width="56" height="56"/>
+      
+      <text x="76" y="44" class="track">T1</text>
+      <text x="76" y="68" class="artist">A1</text>
+      <text x="892" y="52" class="time">1 min. ago</text>
     </g>
-    <line x1="0" y1="128" x2="920" y2="128" class="sep"/>
+    
+      <line x1="28" x2="892" y1="162" y2="162" class="sep"/>
+    
   
     
-    <g transform="translate(24, 138)">
-      <defs>
-        <clipPath id="cover2">
-          <rect width="44" height="44" rx="6" ry="6"/>
-        </clipPath>
-      </defs>
-      <image href="https://img/2" width="44" height="44" clip-path="url(#cover2)" />
-      <text x="56" y="20" class="f track">T2</text>
-      <text x="56" y="40" class="f artist">A2</text>
-      <text x="872" y="32" class="f time">2024-01-02</text>
+    <g transform="translate(28, 162)">
+      
+        <image href="https://img/2" x="0" y="16" width="56" height="56"/>
+      
+      <text x="76" y="44" class="track">T2</text>
+      <text x="76" y="68" class="artist">A2</text>
+      <text x="892" y="52" class="time">2 hr. ago</text>
     </g>
-    <line x1="0" y1="192" x2="920" y2="192" class="sep"/>
+    
+      <line x1="28" x2="892" y1="250" y2="250" class="sep"/>
+    
   
     
-    <g transform="translate(24, 202)">
-      <defs>
-        <clipPath id="cover3">
-          <rect width="44" height="44" rx="6" ry="6"/>
-        </clipPath>
-      </defs>
-      <image href="https://img/3" width="44" height="44" clip-path="url(#cover3)" />
-      <text x="56" y="20" class="f track">T3</text>
-      <text x="56" y="40" class="f artist">A3</text>
-      <text x="872" y="32" class="f time">2024-01-03</text>
+    <g transform="translate(28, 250)">
+      
+        <image href="https://img/3" x="0" y="16" width="56" height="56"/>
+      
+      <text x="76" y="44" class="track">T3</text>
+      <text x="76" y="68" class="artist">A3</text>
+      <text x="892" y="52" class="time">3 d. ago</text>
     </g>
-    <line x1="0" y1="256" x2="920" y2="256" class="sep"/>
+    
   
 </svg>


### PR DESCRIPTION
## Summary
- add human-friendly time formatting and width/theme params
- introduce Spotify-styled SVG card template
- document Spotify recently played usage and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b6cb59fcd8832d9d477965f2059d3e