### PR TITLE
Inline Spotify recently played covers as data URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,12 @@ Query parameters:
 Aliases `/api/recently_played` and `/api/recentlyplayed` redirect to the primary `/api/recently-played` endpoint.
 
 ### 🎧 Recently Played (Spotify Theme)
-![Spotify Recently Played](https://<your-app>.vercel.app/api/recently-played?limit=5&theme=spotify)
+![Spotify Recently Played](https://<your-app>.vercel.app/api/recently-played?theme=spotify&limit=5)
+> Note: GitHub blocks external resources inside SVG. This endpoint inlines album art as data URIs so it renders reliably on GitHub.
 
 Optional width in Markdown:
 
-<img src="https://<your-app>.vercel.app/api/recently-played?limit=5&theme=spotify" width="720" />
+<img src="https://<your-app>.vercel.app/api/recently-played?theme=spotify&limit=5" width="720" />
 
 Health check endpoint:
 

--- a/api/templates/recently_played_spotify.svg.j2
+++ b/api/templates/recently_played_spotify.svg.j2
@@ -22,19 +22,16 @@
       .time  { fill:#9AA3AE;     font: {{ TIME_SIZE }}px/1        -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Arial,"Helvetica Neue",sans-serif; text-anchor:end; }
       .sep   { stroke:#2B2F33; stroke-width:1; opacity:.9; }
       .logo  { fill:#1DB954; }
-      image  { clip-path:url(#cover); }
     </style>
-    <clipPath id="cover">
-      <rect rx="8" ry="8" width="56" height="56"/>
-    </clipPath>
+    <clipPath id="cover"><rect rx="8" ry="8" width="56" height="56"/></clipPath>
   </defs>
 
   <rect x="0" y="0" width="{{ W }}" height="{{ H }}" rx="{{ R }}" ry="{{ R }}" class="card"/>
 
   <g transform="translate({{ PAD_X }}, {{ PAD_Y }})">
-    <g transform="translate(0,0) scale(1.2)">
-      <path class="logo" d="M30 15c8.28 0 15 6.72 15 15s-6.72 15-15 15S15 38.28 15 30 21.72 15 30 15zm6.77 22.25a1.88 1.88 0 0 0-2.58-.63c-3.04 1.86-6.87 2.28-11.38 1.24a1.88 1.88 0 1 0-.82 3.65c5.30 1.19 9.77.67 13.30-1.53.83-.51 1.08-1.6.48-2.73zm1.52-6.18a2.25 2.25 0 0 0-3.10-.76c-3.54 2.16-8.95 2.80-15.03 1.53a2.25 2.25 0 0 0-.93 4.40c7.00 1.48 13.31.74 17.72-1.94a2.25 2.25 0 0 0 .34-3.23zm.38-6.26a2.63 2.63 0 0 0-3.62-.88c-3.97 2.43-10.61 3.23-17.77 1.76a2.63 2.63 0 1 0-1.09 5.14c8.09 1.71 15.78.85 20.90-2.23a2.63 2.63 0 0 0 .58-3.79z"/>
-    </g>
+    <svg x="0" y="0" width="36" height="36" viewBox="0 0 60 60" aria-hidden="true">
+      <path fill="#1DB954" d="M30 15c8.28 0 15 6.72 15 15s-6.72 15-15 15S15 38.28 15 30 21.72 15 30 15zm6.77 22.25a1.88 1.88 0 0 0-2.58-.63c-3.04 1.86-6.87 2.28-11.38 1.24a1.88 1.88 0 1 0-.82 3.65c5.30 1.19 9.77.67 13.30-1.53.83-.51 1.08-1.6.48-2.73zm1.52-6.18a2.25 2.25 0 0 0-3.10-.76c-3.54 2.16-8.95 2.80-15.03 1.53a2.25 2.25 0 0 0-.93 4.40c7.00 1.48 13.31.74 17.72-1.94a2.25 2.25 0 0 0 .34-3.23zm.38-6.26a2.63 2.63 0 0 0-3.62-.88c-3.97 2.43-10.61 3.23-17.77 1.76a2.63 2.63 0 1 0-1.09 5.14c8.09 1.71 15.78.85 20.90-2.23a2.63 2.63 0 0 0 .58-3.79z"/>
+    </svg>
     <text x="64" y="30" class="tSpot">Spotify</text>
     <text x="184" y="30" class="tHead">Recently Played</text>
   </g>
@@ -45,7 +42,7 @@
     {% set y = PAD_Y + 50 + (loop.index0 * ROW_H) %}
     <g transform="translate({{ PAD_X }}, {{ y }})">
       {% if it.cover %}
-        <image href="{{ it.cover }}" x="0" y="16" width="56" height="56"/>
+        <image href="{{ it.cover }}" x="0" y="16" width="56" height="56" preserveAspectRatio="xMidYMid slice" clip-path="url(#cover)"/>
       {% else %}
         <rect x="0" y="16" width="56" height="56" rx="8" ry="8" fill="#2B2F33"/>
       {% endif %}

--- a/tests/golden_spotify_theme.svg
+++ b/tests/golden_spotify_theme.svg
@@ -9,19 +9,16 @@
       .time  { fill:#9AA3AE;     font: 16px/1        -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Arial,"Helvetica Neue",sans-serif; text-anchor:end; }
       .sep   { stroke:#2B2F33; stroke-width:1; opacity:.9; }
       .logo  { fill:#1DB954; }
-      image  { clip-path:url(#cover); }
     </style>
-    <clipPath id="cover">
-      <rect rx="8" ry="8" width="56" height="56"/>
-    </clipPath>
+    <clipPath id="cover"><rect rx="8" ry="8" width="56" height="56"/></clipPath>
   </defs>
 
   <rect x="0" y="0" width="920" height="360" rx="18" ry="18" class="card"/>
 
   <g transform="translate(28, 24)">
-    <g transform="translate(0,0) scale(1.2)">
-      <path class="logo" d="M30 15c8.28 0 15 6.72 15 15s-6.72 15-15 15S15 38.28 15 30 21.72 15 30 15zm6.77 22.25a1.88 1.88 0 0 0-2.58-.63c-3.04 1.86-6.87 2.28-11.38 1.24a1.88 1.88 0 1 0-.82 3.65c5.30 1.19 9.77.67 13.30-1.53.83-.51 1.08-1.6.48-2.73zm1.52-6.18a2.25 2.25 0 0 0-3.10-.76c-3.54 2.16-8.95 2.80-15.03 1.53a2.25 2.25 0 0 0-.93 4.40c7.00 1.48 13.31.74 17.72-1.94a2.25 2.25 0 0 0 .34-3.23zm.38-6.26a2.63 2.63 0 0 0-3.62-.88c-3.97 2.43-10.61 3.23-17.77 1.76a2.63 2.63 0 1 0-1.09 5.14c8.09 1.71 15.78.85 20.90-2.23a2.63 2.63 0 0 0 .58-3.79z"/>
-    </g>
+    <svg x="0" y="0" width="36" height="36" viewBox="0 0 60 60" aria-hidden="true">
+      <path fill="#1DB954" d="M30 15c8.28 0 15 6.72 15 15s-6.72 15-15 15S15 38.28 15 30 21.72 15 30 15zm6.77 22.25a1.88 1.88 0 0 0-2.58-.63c-3.04 1.86-6.87 2.28-11.38 1.24a1.88 1.88 0 1 0-.82 3.65c5.30 1.19 9.77.67 13.30-1.53.83-.51 1.08-1.6.48-2.73zm1.52-6.18a2.25 2.25 0 0 0-3.10-.76c-3.54 2.16-8.95 2.80-15.03 1.53a2.25 2.25 0 0 0-.93 4.40c7.00 1.48 13.31.74 17.72-1.94a2.25 2.25 0 0 0 .34-3.23zm.38-6.26a2.63 2.63 0 0 0-3.62-.88c-3.97 2.43-10.61 3.23-17.77 1.76a2.63 2.63 0 1 0-1.09 5.14c8.09 1.71 15.78.85 20.90-2.23a2.63 2.63 0 0 0 .58-3.79z"/>
+    </svg>
     <text x="64" y="30" class="tSpot">Spotify</text>
     <text x="184" y="30" class="tHead">Recently Played</text>
   </g>
@@ -32,10 +29,10 @@
     
     <g transform="translate(28, 74)">
       
-        <image href="https://img/1" x="0" y="16" width="56" height="56"/>
+        <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=" x="0" y="16" width="56" height="56" preserveAspectRatio="xMidYMid slice" clip-path="url(#cover)"/>
       
-      <text x="76" y="44" class="track">T1</text>
-      <text x="76" y="68" class="artist">A1</text>
+      <text x="76" y="44" class="track">T0</text>
+      <text x="76" y="68" class="artist">A0</text>
       <text x="892" y="52" class="time">1 min. ago</text>
     </g>
     
@@ -45,11 +42,11 @@
     
     <g transform="translate(28, 162)">
       
-        <image href="https://img/2" x="0" y="16" width="56" height="56"/>
+        <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=" x="0" y="16" width="56" height="56" preserveAspectRatio="xMidYMid slice" clip-path="url(#cover)"/>
       
-      <text x="76" y="44" class="track">T2</text>
-      <text x="76" y="68" class="artist">A2</text>
-      <text x="892" y="52" class="time">2 hr. ago</text>
+      <text x="76" y="44" class="track">T1</text>
+      <text x="76" y="68" class="artist">A1</text>
+      <text x="892" y="52" class="time">1 min. ago</text>
     </g>
     
       <line x1="28" x2="892" y1="250" y2="250" class="sep"/>
@@ -58,11 +55,11 @@
     
     <g transform="translate(28, 250)">
       
-        <image href="https://img/3" x="0" y="16" width="56" height="56"/>
+        <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=" x="0" y="16" width="56" height="56" preserveAspectRatio="xMidYMid slice" clip-path="url(#cover)"/>
       
-      <text x="76" y="44" class="track">T3</text>
-      <text x="76" y="68" class="artist">A3</text>
-      <text x="892" y="52" class="time">3 d. ago</text>
+      <text x="76" y="44" class="track">T2</text>
+      <text x="76" y="68" class="artist">A2</text>
+      <text x="892" y="52" class="time">1 min. ago</text>
     </g>
     
   

--- a/util/images.py
+++ b/util/images.py
@@ -1,0 +1,47 @@
+import base64
+import time
+from typing import Dict, Tuple
+
+import requests
+
+DEFAULT_TIMEOUT = (3, 3)
+_TTL = 600  # 10 minutes
+_MAX_ENTRIES = 256
+_cache: Dict[str, Tuple[float, str]] = {}
+
+
+def fetch_data_uri(url: str) -> str:
+    """Fetch an image and return it as a data URI.
+
+    Uses a tiny in-memory cache with TTL to avoid refetching frequently.
+    Returns an empty string on failure.
+    """
+
+    if not url:
+        return ""
+    now = time.time()
+    cached = _cache.get(url)
+    if cached and cached[0] > now:
+        return cached[1]
+
+    for attempt in range(2):
+        try:
+            resp = requests.get(url, timeout=DEFAULT_TIMEOUT)
+        except requests.RequestException:
+            return ""
+        if resp.status_code >= 500 and attempt == 0:
+            continue
+        if resp.status_code != 200:
+            return ""
+        data = resp.content
+        ctype = resp.headers.get("Content-Type", "image/jpeg").split(";")[0]
+        if not ctype.startswith("image/"):
+            ctype = "image/jpeg"
+        data_uri = f"data:{ctype};base64,{base64.b64encode(data).decode()}"
+        _cache[url] = (now + _TTL, data_uri)
+        if len(_cache) > _MAX_ENTRIES:
+            # Evict the oldest item
+            oldest = min(_cache.items(), key=lambda kv: kv[1][0])[0]
+            _cache.pop(oldest, None)
+        return data_uri
+    return ""

--- a/util/spotify.py
+++ b/util/spotify.py
@@ -89,6 +89,13 @@ def _request_with_retry(url, headers, params=None, retries=1):
         return response
 
 
+def smallest_image(images):
+    """Return URL of the smallest image in Spotify's image array."""
+    if not images:
+        return ""
+    return images[-1].get("url", "") or images[0].get("url", "")
+
+
 def get_recently_played(access_token, limit=5):
     headers = {"Authorization": f"Bearer {access_token}"}
     try:


### PR DESCRIPTION
## Summary
- Inline album art using data URIs with caching to render on GitHub
- Add crisp Spotify logo and cover clipping for Spotify theme
- Document SVG limitations and add tests for inlined images

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b6e14dbe58832d90d2cbc299786b09